### PR TITLE
Introduce meta-stable basic variable concept and zero-out sensitivity derivatives w.r.t. them

### DIFF
--- a/Optima/Canonicalizer.cpp
+++ b/Optima/Canonicalizer.cpp
@@ -35,8 +35,8 @@ struct Canonicalizer::Impl
     Index nl = 0;       ///< The number of linearly dependent rows in Wx = [Ax; Jx].
 
     Matrix R;           ///< The matrix R in RWQ = [Ibb Sbn Sbp].
-    Matrix S;           ///< The matrix S' = [Sbsns Sbsnu Sbsp; 0 Sbunu Sbup].
-    Indices jbn;        ///< The order of x variables as x = (xb, xn) = (xbs, xbu, xns, xnu) = (xbe, xbi, xbu, xne, xni, xnu).
+    Matrix S;           ///< The matrix S' = [Sbsns Sbsnu Sbsp].
+    Indices jbn;        ///< The order of x variables as x = (xb, xn) = (xbs, xns, xnu) = (xbe, xbi, xne, xni, xnu).
 
     Index nbs = 0;      ///< The number of basic stable variables.
     Index nbu = 0;      ///< The number of basic unstable variables.
@@ -49,10 +49,10 @@ struct Canonicalizer::Impl
     Index nni = 0;      ///< The number of implicit non-basic stable variables.
 
     Indices bs;         ///< The boolean flags that indicate which variables in x are stable.
-    Indices Kb;         ///< The permutation matrix used to order the basic variables as xb = (xbe, xbi, xbu) with `e` and `i` denoting pivot and non-pivot.
+    Indices Kb;         ///< The permutation matrix used to order the basic variables as xb = (xbe, xbi) with `e` and `i` denoting pivot and non-pivot.
     Indices Kn;         ///< The permutation matrix used to order the non-basic variables as xn = (xne, xni, xnu) with `e` and `i` denoting pivot and non-pivot.
 
-    Indices jsu;        ///< The order of x variables as x = (xs, xu) = (xbs, xns, xbu, xnu) = (xbe, xbi, xne, xni, xbu, xnu).
+    Indices jsu;        ///< The order of x variables as x = (xbs, xns, xnu) = (xbe, xbi, xne, xni, xnu).
 
     Matrix Hprime;      ///< The matrix H' = [Hss Hsp].
     Matrix Vprime;      ///< The matrix V' = [Vps Vpu Vpp].
@@ -207,16 +207,16 @@ struct Canonicalizer::Impl
         //=========================================================================================
 
         // The indices of the basic variables in xs and xu (jbs and jbu respectively)
-        const auto jbs = jb.head(nbs);
-        const auto jbu = jb.tail(nbu);
+        const auto jbs = jb.head(nbs); // nbs === nb
+        const auto jbu = jb.tail(nbu); // nbu === 0
 
         // The indices of the non-basic variables in xs and xu (jns and jnu respectively)
         const auto jns = jn.head(nns);
         const auto jnu = jn.tail(nnu);
 
-        // Initialize jsu = (js, ju) = (jbs, jns, jbu, jnu)
+        // Initialize jsu = (jbs, jns, jnu)
         jsu.resize(nx);
-        jsu << jbs, jns, jbu, jnu;
+        jsu << jbs, jns, jnu;
 
         // The indices of the stable variables js = (jbs, jns) = (jbe, jbi, jne, jni)
         const auto js = jsu.head(ns);

--- a/Optima/SensitivitySolver.cpp
+++ b/Optima/SensitivitySolver.cpp
@@ -68,8 +68,10 @@ struct SensitivitySolver::Impl
         assert(  hc.rows() == nz );
         assert(  vc.rows() == np );
 
-        const auto& js = res.stabilitystatus.js;
-        const auto& ju = res.stabilitystatus.ju;
+        const auto& js  = res.stabilitystatus.js;
+        const auto& ju  = res.stabilitystatus.ju;
+        const auto& jms = res.stabilitystatus.jms;
+
         const auto& Jc = res.Jc;
 
         linearsolver.decompose(Jc);
@@ -83,6 +85,8 @@ struct SensitivitySolver::Impl
             r.w.bottomRows(nz) = -hc.col(i);
             linearsolver.solve(Jc, r, { xc.col(i), pc.col(i), wc.col(i) });
         }
+
+        xc(jms, all).fill(0.0); // remove derivatives associated with meta-stable basic variables!
 
         const auto Wx = res.Jm.W.Wx;
 

--- a/Optima/Stability.hpp
+++ b/Optima/Stability.hpp
@@ -48,6 +48,7 @@ struct StabilityStatus
     IndicesView ju;   ///< The indices of the unstable variables in x.
     IndicesView jlu;  ///< The indices of the lower unstable variables in x.
     IndicesView juu;  ///< The indices of the upper unstable variables in x.
+    IndicesView jms;  ///< The indices of the meta-stable basic variables in x.
     VectorView s;     ///< The stability \eq{s=g-W_{\mathrm{x}}^{T}\lambda} of the x variables.
 };
 
@@ -55,10 +56,12 @@ struct StabilityStatus
 class Stability
 {
 private:
-    Indices jsu;   ///< The indices of the x variables ordered as jsu = (js, ju) = (js, jlu, juu).
-    Index ns = 0;  ///< The number of stable stable variables in js.
+    Indices jsu;   ///< The indices of the x variables ordered as jsu = (js, jlu, juu).
+    Index ns  = 0; ///< The number of stable variables in js.
+    Index nbs = 0; ///< The number of stable basic variables in js.
     Index nlu = 0; ///< The number of lower unstable stable variables in jlu.
     Index nuu = 0; ///< The number of upper unstable stable variables in juu.
+    Index nms = 0; ///< The number of meta-stable basic variables in jbs.
     Vector s;      ///< The stability \eq{s=g+W_{\mathrm{x}}^{T}w} of the *x* variables.
 
 public:


### PR DESCRIPTION
This PR introduces a classification of variables that are simultaneously basic and located on their lower/upper bounds. These variables are called meta-stable. They are considered stable for means of computing the Newton direction. However, sensitivity derivatives associated with these meta-stable basic variables are zero out. This is needed because these variables are at the limit of stability and these derivatives are thus not defined at the bounds. 