### PR TITLE
Replace `eigen4rkt` by `eigen` as conda-forge dep

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -11,7 +11,7 @@ dependencies:
   - clangxx_osx-64  # [osx]
   - clcache  # [win]
   - cmake
-  - eigen4rkt
+  - eigen
   - gxx_linux-64  # [linux]
   - lld  # [unix]
   - ninja


### PR DESCRIPTION
This PR replaces the `eigen4rkt` package that was created in the past to accomodade certain needs in Optima and Reaktoro by the official `eigen` package.